### PR TITLE
Prevent empty words in word bank (fixes #1)

### DIFF
--- a/script.js
+++ b/script.js
@@ -95,11 +95,18 @@ function addWord() {
     const input = document.getElementById('newWord');
     const word = input.value.trim().toUpperCase();
 
+    // Prevent empty words (REQ-WB-02)
+    if (!word) {
+        alert('Word cannot be empty.');
+        return;
+    }
+
     wordBank.push(word);
     input.value = '';
     saveWordBank();
     displayWordBank();
 }
+
 
 function editWord(index) {
     const newWord = prompt('Edit word:', wordBank[index]);


### PR DESCRIPTION
Bug: Word bank allows empty words

Fixes issue#1